### PR TITLE
fix: deployment at #2

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,7 +6,13 @@ module.exports = {
     title: `Kunga`,
     siteUrl: `https://www.yourdomain.tld`
   },
-  plugins: ["gatsby-plugin-google-gtag", "gatsby-plugin-image", "gatsby-plugin-sitemap", "gatsby-plugin-mdx", "gatsby-plugin-sharp", "gatsby-transformer-sharp", {
+  plugins: [ // "gatsby-plugin-google-gtag", 
+              "gatsby-plugin-image", 
+              "gatsby-plugin-sitemap", 
+              "gatsby-plugin-mdx", 
+              "gatsby-plugin-sharp", 
+              "gatsby-transformer-sharp", 
+            {
     resolve: 'gatsby-source-filesystem',
     options: {
       "name": "images",


### PR DESCRIPTION
this pr fixes the broken deployment when I try to remove the `gatsby-plugin-google-gtag` gat's by plug-in